### PR TITLE
Tickets/DM-40029

### DIFF
--- a/python/lsst/ts/tunablelaser/component.py
+++ b/python/lsst/ts/tunablelaser/component.py
@@ -265,6 +265,9 @@ class MainLaser(interfaces.Laser):
             f"Optical alignment is {self.maxi_opg.optical_alignment}"
         )
         self.maxi_opg.set_configuration()
+        await self.csc.evt_opticalConfiguration.set_write(
+            configuration=config.optical_configuration
+        )
 
     def __str__(self):
         return (

--- a/python/lsst/ts/tunablelaser/component.py
+++ b/python/lsst/ts/tunablelaser/component.py
@@ -264,6 +264,7 @@ class MainLaser(interfaces.Laser):
             f"Set optical alignment to {config.optical_configuration}"
             f"Optical alignment is {self.maxi_opg.optical_alignment}"
         )
+        self.maxi_opg.set_configuration()
 
     def __str__(self):
         return (


### PR DESCRIPTION
 * Added call to `maxi_opg.set_configuration` in `MainLaser.configure` to set optical alignment of the laser when connecting to hardware. This fixes the bug reported in DM-40029 and adds the expected behavior that alignment will match what is in the configuration.
 * Started writing to evt_opticalConfiguration to reflect the state of the optical alignment.

* Features to change opticalConfiguration on the fly will come in DM-41426