### PR TITLE
Tickets/DM-41426

### DIFF
--- a/doc/news/DM-40029.bugfix.rst
+++ b/doc/news/DM-40029.bugfix.rst
@@ -1,0 +1,1 @@
+Call setOpticalConfiguration when connecting to the device (CSC disabled->enabled) which means when the laser is ready to be used it will be in the configured optical configuration.

--- a/doc/news/DM-41426.feature.rst
+++ b/doc/news/DM-41426.feature.rst
@@ -1,0 +1,1 @@
+Implmented do_setOpticalConfiguration to allow on-the-fly change changes to the optical configuration. Implemented supporting function in MainLaser component, as well as tracking which laser is being used.

--- a/python/lsst/ts/tunablelaser/component.py
+++ b/python/lsst/ts/tunablelaser/component.py
@@ -137,6 +137,24 @@ class MainLaser(interfaces.Laser):
         self.log.debug("Changing wavelength")
         await self.maxi_opg.change_wavelength(wavelength)
 
+    async def set_optical_configuration(self, optical_configuration):
+        """Change the optical alignment of the laser.
+
+        Parameters
+        ----------
+        optical_configuration: `str`, {straight-through,F1,F2}
+            The optical alignment to switch to.
+        """
+        self.maxi_opg.optical_alignment = optical_configuration
+        self.log.debug(
+            f"Set optical alignment to {optical_configuration}"
+            f"Optical alignment is {self.maxi_opg.optical_alignment}"
+        )
+        await self.maxi_opg.set_configuration()
+        await self.csc.evt_opticalConfiguration.set_write(
+            configuration=optical_configuration
+        )
+
     async def set_output_energy_level(self, output_energy_level):
         """Set the output energy level of the laser.
 

--- a/python/lsst/ts/tunablelaser/csc.py
+++ b/python/lsst/ts/tunablelaser/csc.py
@@ -187,10 +187,8 @@ class LaserCSC(salobj.ConfigurableCsc):
                     detailedState=TunableLaser.LaserDetailedState.NONPROPAGATING
                 )
                 await self.model.connect()
-                try:
-                    await self.model.maxi_opg.set_configuration()
-                except Exception:
-                    pass
+                if self.laser_type == "Main":
+                    await self.model.set_optical_configuration(self.optical_alignment)
                 await self.thermal_ctrl.connect()
             if (
                 self.summary_state == salobj.State.DISABLED

--- a/python/lsst/ts/tunablelaser/csc.py
+++ b/python/lsst/ts/tunablelaser/csc.py
@@ -92,6 +92,7 @@ class LaserCSC(salobj.ConfigurableCsc):
         self.telemetry_task = utils.make_done_future()
         self.simulator = None
         self.thermal_ctrl_simulator = None
+        self.laser_type = None
 
     @property
     def connected(self):
@@ -374,6 +375,7 @@ class LaserCSC(salobj.ConfigurableCsc):
         """Configure the CSC."""
         self.log.debug(f"config={config}")
         self.log.debug(f"Connecting to laser {config.type}")
+        self.laser_type = config.type
         lasercls = getattr(component, f"{config.type}Laser")
         self.model = lasercls(csc=self, simulation_mode=bool(self.simulation_mode))
         self.optical_alignment = config.optical_configuration

--- a/python/lsst/ts/tunablelaser/csc.py
+++ b/python/lsst/ts/tunablelaser/csc.py
@@ -355,10 +355,21 @@ class LaserCSC(salobj.ConfigurableCsc):
             raise salobj.ExpectedError("Not connected.")
 
     async def do_setOpticalConfiguration(self, data):
-        """Not Implemented Yet."""
+        """Change Optical Alignment of the laser.
+        Parameters
+        ----------
+        data - with property 'configuration' setting optical
+               alignment of the laser.
+        """
         self.assert_enabled()
-
-        raise NotImplementedError("Command not implemented yet.")
+        if self.connected:
+            if self.laser_type == "Main":  # only main laser can do this
+                await self.model.set_optical_configuration(data.configuration)
+                await self.evt_opticalConfiguration.set_write(
+                    configuration=data.configuration
+                )
+        else:
+            raise salobj.ExpectedError("Not connected")
 
     async def publish_new_detailed_state(self, new_sub_state):
         """Publish the updated detailed state.


### PR DESCRIPTION
This pull request/branch solves both DM-40029 and DM-41426. They ended up being too intertwined to be worth separating.
* DM-40029: Call setOpticalConfiguration when connecting to the device (CSC disabled->enabled) which means when the laser is ready to be used it will be in the configured optical configuration.
* Implmented do_setOpticalConfiguration to allow on-the-fly change changes to the optical configuration. Implemented supporting function in MainLaser component, as well as tracking which laser is being used.