### PR TITLE
Fixing bugs with tunable laser

### DIFF
--- a/doc/news/dm-44396.bugfix.rst
+++ b/doc/news/dm-44396.bugfix.rst
@@ -1,0 +1,1 @@
+Fixing two bugs with thermal ctrl system. The first is that if its not connected there is a chance it tries to access a None method. The second bug is that it improperly parses results.

--- a/python/lsst/ts/tunablelaser/component.py
+++ b/python/lsst/ts/tunablelaser/component.py
@@ -556,7 +556,10 @@ class TemperatureCtrl(interfaces.CompoWayFModule):
 
     @property
     def temperature(self):
-        return (self.e5dc_b.set_point_register.register_value,)
+        if self.e5dc_b is not None:
+            return (self.e5dc_b.set_point_register.register_value,)
+        else:
+            return (-1,)
 
     async def laser_thermal_turn_on(self):
         if self.e5dc_b is not None:

--- a/python/lsst/ts/tunablelaser/compoway_register.py
+++ b/python/lsst/ts/tunablelaser/compoway_register.py
@@ -479,15 +479,15 @@ class CompoWayFDataRegister(CompoWayFGeneralRegister):
                 self.response_code = await self.component.commander.readexactly(4)
                 self.response_code = self.response_code.decode()
 
-                self.cmd_txt = await self.component.commander.readuntil(b"\x03")
+                self.cmd_txt = await self.component.commander.readuntil(b"\x03")[:-1]
                 self.cmd_txt = self.cmd_txt.decode()
-                self.register_value = self.cmd_txt
-                if self.register_value is None:
-                    self.log.error("Received no valid register value!")
+                try:
+                    self.register_value = int(self.cmd_txt, 16)
+                except Exception as e:
+                    self.log.error(
+                        f"Received no valid register value! {self.cmd_txt} {str(e)}"
+                    )
                     self.register_value = ""
-
-                # trim off ETX byte
-                self.cmd_txt = self.cmd_txt[:-1]
 
                 self.bcc = await self.component.commander.readexactly(1)
                 self.bcc = self.bcc.decode()


### PR DESCRIPTION
Currently tunablelaser is excepting because the byte string isn't being converted to integer

Traceback (most recent call last): File "/opt/lsst/software/stack/miniconda/lib/python3.11/site-packages/lsst/ts/tunablelaser/csc.py", line 138, in telemetry scanner_temperature=float(self.thermal_ctrl.temperature[0]), ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ValueError: could not convert string to float: '00B4\x03'