### PR TITLE
Wavelength and OpticalConfiguration Bugs

### DIFF
--- a/doc/news/DM-48890.bugfix.rst
+++ b/doc/news/DM-48890.bugfix.rst
@@ -1,0 +1,1 @@
+Made sure that change wavelength was fed an integer and added an event for the opticalConfiguration during config

--- a/python/lsst/ts/tunablelaser/component.py
+++ b/python/lsst/ts/tunablelaser/component.py
@@ -133,11 +133,14 @@ class MainLaser(interfaces.Laser):
         ----------
         wavelength : `float`
             The wavelength to change to.
+            This remains as float because it was used in other places.
+            However, it should have been a long int.
 
             :Units: nanometers
         """
         self.log.debug("Changing wavelength")
-        await self.maxi_opg.change_wavelength(wavelength)
+        wave = int(wavelength)
+        await self.maxi_opg.change_wavelength(wave)
 
     async def set_optical_configuration(self, optical_configuration):
         """Change the optical alignment of the laser.

--- a/python/lsst/ts/tunablelaser/csc.py
+++ b/python/lsst/ts/tunablelaser/csc.py
@@ -222,6 +222,9 @@ class LaserCSC(salobj.ConfigurableCsc):
                 await self.model.clear_fault()
                 if self.laser_type == "Main":
                     await self.model.set_optical_configuration(self.optical_alignment)
+                    await self.evt_opticalConfiguration.set_write(
+                        configuration=self.optical_alignment
+                    )
                 await self.thermal_ctrl.connect()
                 await self.fc_client.connect()
                 await self.la_client.connect()


### PR DESCRIPTION
There are two bugs found in the Tunable Laser CSC through some testing on TTS:

1. changeWavelength should actually be a long integer, rather than a float
2. When configuring the CSC with the main laser, we don’t actually set the event of the opticalConfiguration