### PR TITLE
tickets/OSW 2284

### DIFF
--- a/doc/news/OSW-2284.bugfix.rst
+++ b/doc/news/OSW-2284.bugfix.rst
@@ -1,0 +1,1 @@
+Prevented ASCII laser command retries from desynchronizing request and response messages by reconnecting before retrying timeout and retryable device-error responses, serializing retry recovery with other commands, and handling trigger-mode state after burst propagation stops.

--- a/python/lsst/ts/tunablelaser/component.py
+++ b/python/lsst/ts/tunablelaser/component.py
@@ -286,6 +286,7 @@ class MainLaser(interfaces.Laser):
             Raised when mode parameter is not in list of accepted values.
         """
         await self.write_register(*self.m_cpu800.set_propagation_mode(Mode.TRIGGER))
+        await self.set_burst_mode(count=int(self.m_cpu800.burst_length_register.register_value))
 
     async def set_burst_mode(self, count):
         """Set the propagation mode to pulse the laser at regular intervals.

--- a/python/lsst/ts/tunablelaser/csc.py
+++ b/python/lsst/ts/tunablelaser/csc.py
@@ -284,6 +284,8 @@ class LaserCSC(salobj.ConfigurableCsc):
                 return TunableLaser.LaserDetailedState.NONPROPAGATING_CONTINUOUS_MODE
             case Mode.CONTINUOUS, True:
                 return TunableLaser.LaserDetailedState.PROPAGATING_CONTINUOUS_MODE
+            case Mode.TRIGGER, False:
+                return TunableLaser.LaserDetailedState.NONPROPAGATING_BURST_MODE
             case Mode.TRIGGER, True:
                 return TunableLaser.LaserDetailedState.PROPAGATING_BURST_MODE
             case _:

--- a/python/lsst/ts/tunablelaser/interfaces.py
+++ b/python/lsst/ts/tunablelaser/interfaces.py
@@ -33,8 +33,6 @@ from lsst.ts.tunablelaser.wizardry import (
     COMMAND_TIMEOUT,
     DEFAULT_CONNECT_TIMEOUT,
     DEFAULT_SLEEP,
-    DEVICE_TIMEOUT_READ_DELAY,
-    DEVICE_TIMEOUT_READ_RETRIES,
     END_CODE_LEN,
     MRC_SRC_LEN,
     NUMBER_OF_CONNECTION_RETRIES,
@@ -47,14 +45,14 @@ from lsst.ts.tunablelaser.wizardry import (
 from .compoway_register import CompoWayFDataRegister, CompoWayFGeneralRegister, CompoWayFOperationRegister
 from .register import AsciiRegister
 
-ERRORS = [
+RETRYABLE_DEVICE_ERRORS = [
     "(8) Timeout waiting for device answer",
     "(6) No such register name",
 ]
 
 
-class DeviceTimeoutError(Exception):
-    """The controller replied that a downstream device timed out."""
+class RetryableDeviceError(Exception):
+    """The controller replied with a retryable device error."""
 
 
 class Laser(ABC):
@@ -354,8 +352,6 @@ class Laser(ABC):
 
         Raises
         ------
-        DeviceTimeoutError
-            Raised when the laser reports a transient downstream device error.
         RuntimeError
             Raised when the laser reports a non-retryable ASCII error.
         ConnectionError
@@ -371,11 +367,11 @@ class Laser(ABC):
                     if resp:
                         if resp.startswith("'''"):
                             self.log.error(f"{message} failed. Received {resp}.")
-                            if any(error in resp for error in ERRORS):
-                                raise DeviceTimeoutError(resp)
+                            if any(error in resp for error in RETRYABLE_DEVICE_ERRORS):
+                                raise RetryableDeviceError(resp)
                             raise RuntimeError(f"{message} failed.")
                         return resp.rstrip("nmC\r\n")
-            except asyncio.TimeoutError as err:
+            except (asyncio.TimeoutError, RetryableDeviceError) as err:
                 last_error = err
                 self.log.warning(
                     f"Command failed on attempt {attempt + 1}/{NUMBER_OF_RETRIES} for {message!r}: {err!r}"
@@ -452,7 +448,7 @@ class Laser(ABC):
         )
 
     async def read_register(self, register) -> str:
-        """Read an ASCII register with device-timeout retries.
+        """Read an ASCII register.
 
         Parameters
         ----------
@@ -463,27 +459,9 @@ class Laser(ABC):
         -------
         value : `str`
             Decoded register value.
-
-        Raises
-        ------
-        DeviceTimeoutError
-            Raised when retry attempts are exhausted.
         """
-        last_error = None
-        for attempt in range(DEVICE_TIMEOUT_READ_RETRIES + 1):
-            try:
-                register.register_value = await self.send_command(register.create_get_message())
-                return register.register_value
-            except DeviceTimeoutError as err:
-                last_error = err
-                self.log.warning(
-                    f"Device timeout reading {register.module_name}.{register.register_name} "
-                    f"attempt {attempt + 1}/{DEVICE_TIMEOUT_READ_RETRIES + 1}: {err}"
-                )
-                if attempt == DEVICE_TIMEOUT_READ_RETRIES:
-                    break
-                await asyncio.sleep(DEVICE_TIMEOUT_READ_DELAY)
-        raise last_error
+        register.register_value = await self.send_command(register.create_get_message())
+        return register.register_value
 
     async def write_register(self, register, value) -> str:
         """Write an ASCII register and read it back.

--- a/python/lsst/ts/tunablelaser/interfaces.py
+++ b/python/lsst/ts/tunablelaser/interfaces.py
@@ -358,9 +358,9 @@ class Laser(ABC):
             Raised when retries are exhausted without a usable response.
         """
         last_error = None
-        for attempt in range(NUMBER_OF_RETRIES):
-            try:
-                async with self.lock:
+        async with self.lock:
+            for attempt in range(NUMBER_OF_RETRIES):
+                try:
                     async with asyncio.timeout(COMMAND_TIMEOUT):
                         await self.commander.write(message.encode(self.commander.encoding))
                         resp = await self.commander.read_str()
@@ -371,16 +371,17 @@ class Laser(ABC):
                                 raise RetryableDeviceError(resp)
                             raise RuntimeError(f"{message} failed.")
                         return resp.rstrip("nmC\r\n")
-            except (asyncio.TimeoutError, RetryableDeviceError) as err:
-                last_error = err
-                self.log.warning(
-                    f"Command failed on attempt {attempt + 1}/{NUMBER_OF_RETRIES} for {message!r}: {err!r}"
-                )
-                if attempt == NUMBER_OF_RETRIES - 1:
-                    break
-                if not await self._reconnect_after_timeout():
-                    break
-                await asyncio.sleep(DEFAULT_SLEEP)
+                except (asyncio.TimeoutError, RetryableDeviceError) as err:
+                    last_error = err
+                    self.log.warning(
+                        f"Command failed on attempt {attempt + 1}/{NUMBER_OF_RETRIES} for "
+                        f"{message!r}: {err!r}"
+                    )
+                    if attempt == NUMBER_OF_RETRIES - 1:
+                        break
+                    if not await self._reconnect_after_timeout():
+                        break
+                    await asyncio.sleep(DEFAULT_SLEEP)
         raise ConnectionError("Response not received after retry exhaustion.") from last_error
 
     def _iter_canbus_modules(self) -> Iterator["CanbusModule"]:

--- a/python/lsst/ts/tunablelaser/interfaces.py
+++ b/python/lsst/ts/tunablelaser/interfaces.py
@@ -302,10 +302,42 @@ class Laser(ABC):
         """
         raise NotImplementedError
 
+    async def _disconnect(self) -> None:
+        # Public disconnect acquires connect_lock before calling this.
+        # connect calls this directly because it already holds connect_lock,
+        # avoiding re-entry into the non-reentrant asyncio.Lock.
+        await self.commander.close()
+        self.commander = self.create_empty_client()
+
     async def disconnect(self) -> None:
         """Disconnect from the laser."""
-        await self.commander.close()
-        self.commander = tcpip.Client(host="", port=0, log=self.log)
+        async with self.connect_lock:
+            await self._disconnect()
+
+    async def _reconnect_after_timeout(self) -> bool:
+        """Reconnect after a command timeout.
+
+        A command timeout can leave a late response in the TCP stream. Reusing
+        the same client for a retry can then pair the retry with stale bytes
+        from the previous command.
+        """
+        try:
+            await self.disconnect()
+        except Exception:
+            self.log.exception("Failed to close commander after command timeout.")
+            return False
+
+        if not hasattr(self, "host") or not hasattr(self, "port"):
+            self.log.error("Cannot reconnect after timeout because host/port are not configured.")
+            return False
+
+        try:
+            await self.connect()
+        except Exception:
+            self.log.exception("Failed to reconnect after command timeout.")
+            return False
+
+        return self.commander.connected
 
     async def send_command(self, message) -> str:
         """Send one ASCII command and return the decoded response.
@@ -349,6 +381,8 @@ class Laser(ABC):
                     f"Command failed on attempt {attempt + 1}/{NUMBER_OF_RETRIES} for {message!r}: {err!r}"
                 )
                 if attempt == NUMBER_OF_RETRIES - 1:
+                    break
+                if not await self._reconnect_after_timeout():
                     break
                 await asyncio.sleep(DEFAULT_SLEEP)
         raise ConnectionError("Response not received after retry exhaustion.") from last_error
@@ -484,6 +518,9 @@ class Laser(ABC):
         refresh_time_dt = loop.time() - refresh_time_start
         self.log.debug(f"Refresh all registers took {refresh_time_dt:.3f}s")
 
+    def create_empty_client(self) -> tcpip.Client:
+        return tcpip.Client(host="", port=0, log=self.log)
+
     async def connect(self) -> None:
         """Connect to the laser.
 
@@ -492,23 +529,33 @@ class Laser(ABC):
         RuntimeError
             Raised if all connection attempts fail.
         """
-        for _ in range(NUMBER_OF_CONNECTION_RETRIES):
-            try:
-                self.commander = tcpip.Client(
-                    host=self.host,
-                    port=self.port,
-                    log=self.log,
-                    terminator=bytes(self.terminator),
-                    encoding=self.encoding,
-                )
-                async with asyncio.timeout(self.connect_timeout):
-                    await self.commander.start_task
-            except Exception:
-                self.log.exception("Connection failed.")
+        async with self.connect_lock:
+            last_error = None
             if self.commander.connected:
-                break
-        if not self.commander.connected:
-            raise RuntimeError("Connect call failed.")
+                await self._disconnect()
+            for _ in range(NUMBER_OF_CONNECTION_RETRIES):
+                commander = self.create_empty_client()
+                try:
+                    commander = tcpip.Client(
+                        host=self.host,
+                        port=self.port,
+                        log=self.log,
+                        terminator=bytes(self.terminator),
+                        encoding=self.encoding,
+                    )
+                    async with asyncio.timeout(self.connect_timeout):
+                        await commander.start_task
+                    if commander.connected:
+                        self.commander = commander
+                        return
+                except Exception as e:
+                    last_error = e
+                    self.log.exception("Connection failed.")
+                finally:
+                    if not commander.connected:
+                        await commander.close()
+                await asyncio.sleep(DEFAULT_SLEEP)
+        raise RuntimeError("Connect call failed.") from last_error
 
 
 class CanbusModule(ABC):

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -28,6 +28,7 @@ import pytest
 from parameterized import parameterized
 
 from lsst.ts import salobj, tunablelaser
+from lsst.ts.tunablelaser.enums import Mode
 from lsst.ts.xml.enums import TunableLaser
 
 STD_TIMEOUT = 5
@@ -285,6 +286,30 @@ class TunableLaserCscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTe
                 detailedState=TunableLaser.LaserDetailedState.PROPAGATING_BURST_MODE,
             )
             await self.remote.cmd_triggerBurst.set_start(timeout=STD_TIMEOUT)
+            await self.remote.cmd_stopPropagateLaser.set_start(timeout=STD_TIMEOUT)
+            await self.assert_next_sample(
+                topic=self.remote.evt_detailedState,
+                detailedState=TunableLaser.LaserDetailedState.NONPROPAGATING_BURST_MODE,
+            )
+
+    @parameterized.expand([(""), ("stubbs.yaml")])
+    async def test_trigger_mode_not_propagating_calculates_burst_mode(self, config):
+        async with self.make_csc(initial_state=salobj.State.ENABLED, simulation_mode=1, override=config):
+            assert self.csc.model is not None
+            if config == "stubbs.yaml":
+                power_register = self.csc.model.m_cpu800.power_id_0x12_register
+                mode_register = self.csc.model.m_cpu800.continuous_burst_mode_trigger_burst_id_0x12_register
+            else:
+                power_register = self.csc.model.m_cpu800.power_register_2
+                mode_register = self.csc.model.m_cpu800.continous_burst_mode_trigger_burst_register
+
+            power_register.register_value = "OFF"
+            mode_register.register_value = Mode.TRIGGER
+
+            self.assertEqual(
+                self.csc.calculate_detailed_state(),
+                TunableLaser.LaserDetailedState.NONPROPAGATING_BURST_MODE,
+            )
 
     @parameterized.expand([(""), ("stubbs.yaml")])
     async def test_tempctrl(self, config):

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -26,7 +26,7 @@ import unittest.mock
 
 from lsst.ts.tunablelaser.canbus_modules import CPU8000, MaxiOPG
 from lsst.ts.tunablelaser.component import FanControlClient, LaserAlignmentClient, TemperatureCtrl
-from lsst.ts.tunablelaser.interfaces import DeviceTimeoutError, Laser
+from lsst.ts.tunablelaser.interfaces import Laser
 
 
 class FakeLaser(Laser):
@@ -186,7 +186,7 @@ class TestLaserRegisterRefresh(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
-    async def test_read_register_raises_on_triple_quote_error_response(self):
+    async def test_read_register_raises_connection_error_on_retryable_device_error(self):
         laser = FakeLaser()
         laser.commander = unittest.mock.AsyncMock()
         laser.commander.encoding = "ascii"
@@ -195,7 +195,7 @@ class TestLaserRegisterRefresh(unittest.IsolatedAsyncioTestCase):
             return_value="'''Error: (8) Timeout waiting for device answer"
         )
 
-        with self.assertRaisesRegex(DeviceTimeoutError, "Timeout waiting for device answer"):
+        with self.assertRaisesRegex(ConnectionError, "retry exhaustion"):
             await laser.read_register(laser.cpu8000.power_register)
 
         self.assertIsNone(laser.cpu8000.power_register.register_value)
@@ -251,6 +251,46 @@ class TestLaserRegisterRefresh(unittest.IsolatedAsyncioTestCase):
 
         laser = FakeLaser()
         first_commander = TimeoutCommander()
+        second_commander = HealthyCommander()
+        laser.commander = first_commander
+        laser.host = "127.0.0.1"
+        laser.port = 12345
+
+        async def connect():
+            laser.commander = second_commander
+
+        laser.connect = unittest.mock.AsyncMock(side_effect=connect)
+
+        with unittest.mock.patch("lsst.ts.tunablelaser.interfaces.DEFAULT_SLEEP", 0):
+            await laser.read_register(laser.cpu8000.power_register)
+
+        first_commander.close.assert_awaited_once()
+        laser.connect.assert_awaited_once()
+        second_commander.write.assert_awaited_once()
+        second_commander.read_str.assert_awaited_once()
+        self.assertEqual(laser.cpu8000.power_register.register_value, "ON")
+
+    async def test_send_command_reconnects_before_retry_after_retryable_device_error(self):
+        class RetryableErrorCommander:
+            encoding = "ascii"
+            connected = True
+
+            def __init__(self):
+                self.close = unittest.mock.AsyncMock()
+                self.write = unittest.mock.AsyncMock()
+                self.read_str = unittest.mock.AsyncMock(return_value="'''Error: (6) No such register name")
+
+        class HealthyCommander:
+            encoding = "ascii"
+            connected = True
+
+            def __init__(self):
+                self.close = unittest.mock.AsyncMock()
+                self.write = unittest.mock.AsyncMock()
+                self.read_str = unittest.mock.AsyncMock(return_value="ON")
+
+        laser = FakeLaser()
+        first_commander = RetryableErrorCommander()
         second_commander = HealthyCommander()
         laser.commander = first_commander
         laser.host = "127.0.0.1"

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -310,6 +310,67 @@ class TestLaserRegisterRefresh(unittest.IsolatedAsyncioTestCase):
         second_commander.read_str.assert_awaited_once()
         self.assertEqual(laser.cpu8000.power_register.register_value, "ON")
 
+    async def test_command_waits_for_retry_reconnect_to_complete(self):
+        class RetryableErrorCommander:
+            encoding = "ascii"
+            connected = True
+
+            def __init__(self):
+                self.close = unittest.mock.AsyncMock()
+                self.write = unittest.mock.AsyncMock()
+                self.read_str = unittest.mock.AsyncMock(
+                    return_value="'''Error: (8) Timeout waiting for device answer"
+                )
+
+        class EmptyCommander:
+            encoding = "ascii"
+            connected = False
+
+            def __init__(self):
+                self.close = unittest.mock.AsyncMock()
+                self.write = unittest.mock.AsyncMock(
+                    side_effect=AssertionError("Command used reconnect placeholder client.")
+                )
+                self.read_str = unittest.mock.AsyncMock()
+
+        class HealthyCommander:
+            encoding = "ascii"
+            connected = True
+
+            def __init__(self):
+                self.close = unittest.mock.AsyncMock()
+                self.write = unittest.mock.AsyncMock()
+                self.read_str = unittest.mock.AsyncMock(side_effect=["ON", "19A"])
+
+        laser = FakeLaser()
+        first_commander = RetryableErrorCommander()
+        empty_commander = EmptyCommander()
+        healthy_commander = HealthyCommander()
+        reconnect_started = asyncio.Event()
+        laser.commander = first_commander
+        laser.host = "127.0.0.1"
+        laser.port = 12345
+        laser.create_empty_client = unittest.mock.Mock(return_value=empty_commander)
+
+        async def connect():
+            reconnect_started.set()
+            await asyncio.sleep(0.01)
+            laser.commander = healthy_commander
+
+        laser.connect = unittest.mock.AsyncMock(side_effect=connect)
+
+        with unittest.mock.patch("lsst.ts.tunablelaser.interfaces.DEFAULT_SLEEP", 0):
+            first_read_task = asyncio.create_task(laser.read_register(laser.cpu8000.power_register))
+            await reconnect_started.wait()
+            second_read_task = asyncio.create_task(
+                laser.read_register(laser.cpu8000.display_current_register)
+            )
+            await asyncio.gather(first_read_task, second_read_task)
+
+        empty_commander.write.assert_not_awaited()
+        self.assertEqual(laser.cpu8000.power_register.register_value, "ON")
+        self.assertEqual(laser.cpu8000.display_current_register.register_value, "19A")
+
     async def test_connect_replaces_connected_commander_without_deadlock(self):
         class Commander:
             encoding = "ascii"

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -25,7 +25,7 @@ import unittest
 import unittest.mock
 
 from lsst.ts.tunablelaser.canbus_modules import CPU8000, MaxiOPG
-from lsst.ts.tunablelaser.component import FanControlClient, LaserAlignmentClient, TemperatureCtrl
+from lsst.ts.tunablelaser.component import FanControlClient, LaserAlignmentClient, MainLaser, TemperatureCtrl
 from lsst.ts.tunablelaser.interfaces import Laser
 
 
@@ -344,6 +344,16 @@ class TestLaserRegisterRefresh(unittest.IsolatedAsyncioTestCase):
             terminator=bytes(laser.terminator),
             encoding=laser.encoding,
         )
+
+    async def test_main_laser_trigger_burst_reuses_cached_burst_length_as_int(self):
+        laser = MainLaser(log=logging.getLogger(__name__))
+        laser.m_cpu800.burst_length_register.register_value = "1"
+        laser.write_register = unittest.mock.AsyncMock()
+        laser.set_burst_mode = unittest.mock.AsyncMock()
+
+        await laser.trigger_burst()
+
+        laser.set_burst_mode.assert_awaited_once_with(count=1)
 
     async def test_simulated_tempctrl_write_register_updates_authoritative_mock(self):
         controller = TemperatureCtrl(log=logging.getLogger(__name__), simulation_mode=True)

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -27,7 +27,6 @@ import unittest.mock
 from lsst.ts.tunablelaser.canbus_modules import CPU8000, MaxiOPG
 from lsst.ts.tunablelaser.component import FanControlClient, LaserAlignmentClient, TemperatureCtrl
 from lsst.ts.tunablelaser.interfaces import DeviceTimeoutError, Laser
-from lsst.ts.tunablelaser.wizardry import NUMBER_OF_RETRIES
 
 
 class FakeLaser(Laser):
@@ -217,17 +216,94 @@ class TestLaserRegisterRefresh(unittest.IsolatedAsyncioTestCase):
 
     async def test_send_command_retries_timeout_until_exhaustion(self):
         laser = FakeLaser()
-        laser.commander = unittest.mock.AsyncMock()
-        laser.commander.encoding = "ascii"
-        laser.commander.write = unittest.mock.AsyncMock(side_effect=asyncio.TimeoutError())
-        laser.commander.read_str = unittest.mock.AsyncMock()
+        commander = unittest.mock.AsyncMock()
+        commander.encoding = "ascii"
+        commander.write = unittest.mock.AsyncMock(side_effect=asyncio.TimeoutError())
+        commander.read_str = unittest.mock.AsyncMock()
+        laser.commander = commander
 
         with self.assertRaisesRegex(ConnectionError, "retry exhaustion"):
             await laser.read_register(laser.cpu8000.power_register)
 
-        self.assertEqual(laser.commander.write.await_count, NUMBER_OF_RETRIES)
-        laser.commander.read_str.assert_not_awaited()
+        commander.close.assert_awaited_once()
+        commander.write.assert_awaited_once()
+        commander.read_str.assert_not_awaited()
         self.assertIsNone(laser.cpu8000.power_register.register_value)
+
+    async def test_send_command_reconnects_before_retry_after_timeout(self):
+        class TimeoutCommander:
+            encoding = "ascii"
+            connected = False
+
+            def __init__(self):
+                self.close = unittest.mock.AsyncMock()
+                self.write = unittest.mock.AsyncMock(side_effect=asyncio.TimeoutError())
+                self.read_str = unittest.mock.AsyncMock()
+
+        class HealthyCommander:
+            encoding = "ascii"
+            connected = True
+
+            def __init__(self):
+                self.close = unittest.mock.AsyncMock()
+                self.write = unittest.mock.AsyncMock()
+                self.read_str = unittest.mock.AsyncMock(return_value="ON")
+
+        laser = FakeLaser()
+        first_commander = TimeoutCommander()
+        second_commander = HealthyCommander()
+        laser.commander = first_commander
+        laser.host = "127.0.0.1"
+        laser.port = 12345
+
+        async def connect():
+            laser.commander = second_commander
+
+        laser.connect = unittest.mock.AsyncMock(side_effect=connect)
+
+        with unittest.mock.patch("lsst.ts.tunablelaser.interfaces.DEFAULT_SLEEP", 0):
+            await laser.read_register(laser.cpu8000.power_register)
+
+        first_commander.close.assert_awaited_once()
+        laser.connect.assert_awaited_once()
+        second_commander.write.assert_awaited_once()
+        second_commander.read_str.assert_awaited_once()
+        self.assertEqual(laser.cpu8000.power_register.register_value, "ON")
+
+    async def test_connect_replaces_connected_commander_without_deadlock(self):
+        class Commander:
+            encoding = "ascii"
+
+            def __init__(self, connected):
+                self.connected = connected
+                self.close = unittest.mock.AsyncMock()
+                self.start_task = asyncio.Future()
+                self.start_task.set_result(None)
+
+        laser = FakeLaser()
+        laser.host = "127.0.0.1"
+        laser.port = 12345
+        old_commander = Commander(connected=True)
+        empty_commander = Commander(connected=False)
+        new_commander = Commander(connected=True)
+        laser.commander = old_commander
+        laser.create_empty_client = unittest.mock.Mock(return_value=empty_commander)
+
+        with unittest.mock.patch(
+            "lsst.ts.tunablelaser.interfaces.tcpip.Client",
+            return_value=new_commander,
+        ) as client_factory:
+            await asyncio.wait_for(laser.connect(), timeout=1)
+
+        old_commander.close.assert_awaited_once()
+        self.assertIs(laser.commander, new_commander)
+        client_factory.assert_called_once_with(
+            host=laser.host,
+            port=laser.port,
+            log=laser.log,
+            terminator=bytes(laser.terminator),
+            encoding=laser.encoding,
+        )
 
     async def test_simulated_tempctrl_write_register_updates_authoritative_mock(self):
         controller = TemperatureCtrl(log=logging.getLogger(__name__), simulation_mode=True)


### PR DESCRIPTION
- **Avoid laser message desync after command timeout**
- **Reconnect before retrying device-reported laser errors**
- **Handle trigger mode after burst stop for MainLaser.**
- **Serialize laser command retry recovery**
- **fixup! Serialize laser command retry recovery**
